### PR TITLE
Updates content_for block to accept record object.

### DIFF
--- a/lib/active_admin/views/translate_attributes_table.rb
+++ b/lib/active_admin/views/translate_attributes_table.rb
@@ -17,9 +17,11 @@ module ActiveAdmin
                 header_content_for(attr)
               end
             end
-            td do
-              ::I18n.with_locale locale do
-                content_for(block || attr)
+            @collection.each do |record|
+              td do
+                ::I18n.with_locale locale do
+                  content_for(record, block || attr)
+                end
               end
             end
           end


### PR DESCRIPTION
I was getting an error in activeadmin's content_for. Checking out their source - they are now passing in the record object by looping through the @collection instance variable in the builder method. Adding this loop fixed my issue and rendered the translations (both) properly on the show page.

Hope this helps someone else :)
David