### PR TITLE
Fixed problem when block f.translate_inputs called first in form

### DIFF
--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -17,6 +17,8 @@ module ActiveAdmin
           html = "".html_safe
         end
 
+        template.assign(has_many_block: true)
+
         html << template.content_tag(:div, :class => "activeadmin-translate #{ translate_id }") do
           locale_tabs << locale_fields(name, block) << tab_script
         end


### PR DESCRIPTION
Fixing situation, when method *translate_inputs* called before *inputs* which renders only last input field provided in *translate_inputs* block
```
form do |f|
  f.semantic_errors

  f.translate_inputs do |t|
    #international input fields
  end

  f.inputs do
    # rest of inputs
  end

  actions
end
```

https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/form_builder.rb#L7