### PR TITLE
Make translate_inputs compatible with mobility

### DIFF
--- a/lib/active_admin/translate/form_builder.rb
+++ b/lib/active_admin/translate/form_builder.rb
@@ -44,7 +44,12 @@ module ActiveAdmin
       #
       def locale_fields(name, block)
         ::I18n.available_locales.map do |locale|
-          translation = object.translation_for(locale)
+          translation = 
+            if object.respond_to?(:translation_for)
+              object.translation_for(locale)
+            else
+              mobility_translation_for(object, locale)
+            end
           translation.instance_variable_set(:@errors, object.errors) if locale == I18n.default_locale
 
           fields = proc do |form|
@@ -56,6 +61,13 @@ module ActiveAdmin
         end.join.html_safe
       end
 
+      def mobility_translation_for(object, locale)
+        locale = locale.to_s
+        translations = object.translations
+        translation = translations.find { |t| t.locale == locale }
+        translation ||= translations.build(locale: locale)
+        translation
+      end
 
       # Create the locale tab to switch the translations.
       #


### PR DESCRIPTION
If one uses mobility instead of globalize, there are workarounds for `translate_attributes_table_for` in show views, but not for `translate_inputs` in forms, as far as I know. So my change should add compatibility, at least for `translate_inputs`, for mobility.
The only thing needed is to retrieve or build the right translation. with `translation_for`. Mobility has this method, but it's not called directly on the object, and I could not find a way to hack Mobility that way / retrieve the Mobility translation_for method somehow.
So here my (working) best bet on where to put the code: directly into the form builder. Let me know if you have a better idea.